### PR TITLE
Removing the dependency on 'certified' gem

### DIFF
--- a/lib/bandwidth/client.rb
+++ b/lib/bandwidth/client.rb
@@ -1,5 +1,4 @@
 require 'faraday'
-require 'certified'
 require 'json'
 require 'active_support/core_ext/string/inflections'
 

--- a/ruby-bandwidth.gemspec
+++ b/ruby-bandwidth.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday"
   spec.add_dependency "json"
   spec.add_dependency "activesupport"
-  spec.add_dependency "certified"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
`certified` gem helped with issues in Ruby 1.9 with regards to cert it is not needed for Ruby 2.0.0 and above

Related issue: #23 23