### PR TITLE
Don't camel case sip headers, they start with X- and are required by the api

### DIFF
--- a/lib/bandwidth/client.rb
+++ b/lib/bandwidth/client.rb
@@ -153,7 +153,11 @@ module Bandwidth
         when v.is_a?(Hash)
           result = {}
           v.each do |k, val|
-            result[k.to_s().camelcase(:lower)] = camelcase(val)
+            if( k.to_s == 'sip_headers') # Don't camel case the sip headers, they probably start with X- which is required by the API to be upper case
+              result[k.to_s()] = val
+            else     
+              result[k.to_s().camelcase(:lower)] = camelcase(val)
+            end
           end
           result
         else

--- a/spec/bandwidth/call_spec.rb
+++ b/spec/bandwidth/call_spec.rb
@@ -30,7 +30,16 @@ describe Bandwidth::Call do
       client.stubs.get('/v1/users/userId/calls/1') {|env| [200, {}, template_json]}
       expect(Call.create(client, {:from=>'from', :to=>'to'}).to_data()).to eql(template_item)
     end
+      
+    it 'should create a new item with the sip_headers' do
+      raw_data = { :from => "from", :to => "to", :sip_headers => { "X-Header-1" => "header_1" } }
+      client.stubs.post('/v1/users/userId/calls', raw_data.to_json.to_s) {|env| [201, {'Location' => '/v1/users/userId/calls/1'}, '']}
+      client.stubs.get('/v1/users/userId/calls/1') {|env| [200, {}, template_json]}        
+      expect(Call.create(client,raw_data).to_data()).to eql(template_item)
+    end
+      
   end
+    
 
   describe '#update' do
     it 'should change item' do


### PR DESCRIPTION
This fixes an issue where by X- sip headers couldn't be set in the create call due to the fact that all headers were being camel cased.  I handled this by just telling it to ignore the sip_headers key when performing the camel case.  