### PR TITLE
Fixed another small issue around the sip headers - we now camel case the key

### DIFF
--- a/lib/bandwidth/client.rb
+++ b/lib/bandwidth/client.rb
@@ -154,7 +154,7 @@ module Bandwidth
           result = {}
           v.each do |k, val|
             if( k.to_s == 'sip_headers') # Don't camel case the sip headers, they probably start with X- which is required by the API to be upper case
-              result[k.to_s()] = val
+              result[k.to_s().camelcase(:lower)] = val
             else     
               result[k.to_s().camelcase(:lower)] = camelcase(val)
             end

--- a/spec/bandwidth/call_spec.rb
+++ b/spec/bandwidth/call_spec.rb
@@ -32,10 +32,12 @@ describe Bandwidth::Call do
     end
       
     it 'should create a new item with the sip_headers' do
-      raw_data = { :from => "from", :to => "to", :sip_headers => { "X-Header-1" => "header_1" } }
-      client.stubs.post('/v1/users/userId/calls', raw_data.to_json.to_s) {|env| [201, {'Location' => '/v1/users/userId/calls/1'}, '']}
+      request_data = { :from => "from", :to => "to", :sip_headers => { "X-Header-1" => "header_1" } }
+      response_data = { :from => "from", :to => "to", :sipHeaders => { "X-Header-1" => "header_1" } }
+        
+      client.stubs.post('/v1/users/userId/calls', response_data.to_json.to_s) {|env| [201, {'Location' => '/v1/users/userId/calls/1'}, '']}
       client.stubs.get('/v1/users/userId/calls/1') {|env| [200, {}, template_json]}        
-      expect(Call.create(client,raw_data).to_data()).to eql(template_item)
+      expect(Call.create(client,request_data).to_data()).to eql(template_item)
     end
       
   end


### PR DESCRIPTION
Another small bug fix.  I updated the tests to correctly check that the outputted sip key name was correct.